### PR TITLE
turn mode parameter into string for dotnet install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@ class dotnet {
 
     file { 'dotNetFx40_Full_x86_x64.exe':
       path    => 'C:\staging\dotnet\dotNetFx40_Full_x86_x64.exe',
-      mode    => 0755,
+      mode    => '0755',
       owner   => 'vagrant',
       require => Staging::File['dotNetFx40_Full_x86_x64.exe'],
       before  => Package['Microsoft .NET Framework 4 Extended'],


### PR DESCRIPTION
For 2015.2 an error will be flagged unless this parameter is a string. Pretty minor change.
